### PR TITLE
feat: standardize chatlog format and filename

### DIFF
--- a/src/handlers/handleSaveAndUploadChatLog.ts
+++ b/src/handlers/handleSaveAndUploadChatLog.ts
@@ -94,12 +94,12 @@ export async function handleSaveAndUploadChatLog(
   // Define paths
   // Local path: targetProjectDir/.chat/
   const localChatDir = path.join(targetProjectDir, sourceDirName);
-  const chatLogFilename = `chat_log_${safeUserId}_${safeProjectName}_${timestamp}.md`; // Include user/project in filename for local clarity
+  const chatLogFilename = `chat_log_${editorType}_${safeUserId}_${safeProjectName}_${timestamp}.md`; // Include user/project in filename for local clarity
   const localFilePath = path.join(localChatDir, chatLogFilename);
 
   // GitHub path: project-logs/[PROJECT]/[USERID]/[SOURCE]/[FILENAME]
   // Keep the simpler timestamp-based filename for GitHub upload as context is in the path
-  const githubChatLogFilename = `chat_log_${timestamp}.md`;
+  const githubChatLogFilename = `chat_log_${editorType}_${timestamp}.md`;
   const githubFilePath = `project-logs/${safeProjectName}/${safeUserId}/${sourceDirName}/${githubChatLogFilename}`;
 
   console.error(`Local Log Path: ${localFilePath}`);

--- a/src/handlers/parser/cursorChatParser.ts
+++ b/src/handlers/parser/cursorChatParser.ts
@@ -843,56 +843,26 @@ export async function getCursorConversationHistory(
 export function formatConversationHistory(
   history: ConversationHistory,
 ): string {
-  let markdown = "# Conversation History\n\n";
-
-  markdown += `**Editor:** ${history.editor.charAt(0).toUpperCase() + history.editor.slice(1)}\n`;
-  markdown += `**Project Name:** ${history.projectName || "Unknown"}\n`;
-  markdown += `**Project Path:** ${history.projectPath || "Unknown"}\n`;
-  if (history.workspaceName) {
-    markdown += `**Workspace Name:** ${history.workspaceName}\n`;
-  }
-  markdown += "\n---\n";
-
   if (
-    Array.isArray(history.conversations) &&
-    history.conversations.length > 0
+    !history || 
+    !Array.isArray(history.conversations) ||
+    history.conversations.length === 0
   ) {
-    // Option 1: Format only the most recent conversation
-    const latestConvo = history.conversations[0]; // Assumes sorted by lastUpdatedAt desc
-    markdown += `\n## Latest Conversation (${latestConvo.metadata?.title || latestConvo.composerId})\n\n`;
-    if (latestConvo.metadata?.createdAt) {
-      markdown += `**Created:** ${new Date(latestConvo.metadata.createdAt).toLocaleString()}\n`;
-    }
-    if (latestConvo.metadata?.lastUpdatedAt) {
-      markdown += `**Last Updated:** ${new Date(latestConvo.metadata.lastUpdatedAt).toLocaleString()}\n`;
-    }
-    markdown += "\n";
-
-    latestConvo.messages.forEach((message) => {
-      markdown += `**${message.role === "user" ? "User" : "Assistant"}:**\n`;
-      markdown += `${message.content || ""}\n\n`;
-    });
-
-    // Option 2: Format all conversations (could be very long)
-    /*
-         history.conversations.forEach((convo) => {
-             markdown += `\n## Conversation: ${convo.metadata?.title || convo.composerId}\n\n`;
-              if (convo.metadata?.createdAt) markdown += `**Created:** ${new Date(convo.metadata.createdAt).toLocaleString()}\n`;
-              if (convo.metadata?.lastUpdatedAt) markdown += `**Last Updated:** ${new Date(convo.metadata.lastUpdatedAt).toLocaleString()}\n\n`;
-
-             convo.messages.forEach((message) => {
-                 markdown += `**${message.role === 'user' ? 'User' : 'Assistant'}:**\n`;
-                 markdown += `${message.content || ''}\n\n`;
-             });
-             markdown += `---\n`;
-         });
-         */
-  } else {
-    markdown +=
-      "_No relevant conversation history found for this workspace._\\n\\n";
+    return ""; 
   }
 
-  return markdown;
+  const latestConvo = history.conversations[0]; 
+
+  if (!latestConvo || !Array.isArray(latestConvo.messages) || latestConvo.messages.length === 0) {
+    return ""; 
+  }
+
+  let formattedMessages = "";
+  latestConvo.messages.forEach((message) => {
+    formattedMessages += `${message.role === "user" ? "user" : "assistant"}: ${message.content || ""}\n\n`;
+  });
+  
+  return formattedMessages;
 }
 
 // Ensure sqlite3 dependency is added: npm install sqlite3 @types/sqlite3

--- a/src/handlers/parser/zedChatParser.ts
+++ b/src/handlers/parser/zedChatParser.ts
@@ -211,32 +211,24 @@ export async function getZedConversationHistory(
 export function formatZedConversationHistory(
   history: ZedConversationHistory,
 ): string {
-  let markdown = `# Conversation History\n\n`;
-
-  markdown += `**Editor:** ${history.editor.charAt(0).toUpperCase() + history.editor.slice(1)}\n`;
-  markdown += `**Project Name:** ${history.projectName || "Unknown"}\n`;
-  markdown += `**Project Path:** ${history.projectPath || "Unknown"}\n`;
-  markdown += `\n---\n`;
-
-  // Zed parser currently only returns the latest conversation
   if (
-    Array.isArray(history.conversations) &&
-    history.conversations.length > 0
+    !history || 
+    !Array.isArray(history.conversations) ||
+    history.conversations.length === 0
   ) {
-    const convo = history.conversations[0];
-    markdown += `\n## Conversation (${convo.metadata?.title || convo.conversationId})\n\n`;
-    if (convo.metadata?.lastUpdatedAt) {
-      markdown += `**Last Updated:** ${new Date(convo.metadata.lastUpdatedAt).toLocaleString()}\n`;
-    }
-    markdown += `\n`;
-
-    convo.messages.forEach((message) => {
-      markdown += `**${message.role === "user" ? "User" : "Assistant"}:**\n`;
-      markdown += `${message.content || ""}\n\n`; // Ensure newline separation
-    });
-  } else {
-    markdown += "_No conversation history found or extracted._\n\n";
+    return "";
   }
 
-  return markdown;
+  const convo = history.conversations[0]; 
+
+  if (!convo || !Array.isArray(convo.messages) || convo.messages.length === 0) {
+    return "";
+  }
+
+  let formattedMessages = "";
+  convo.messages.forEach((message) => {
+    formattedMessages += `${message.role === "user" ? "user" : "assistant"}: ${message.content || ""}\n\n`;
+  });
+  
+  return formattedMessages;
 }


### PR DESCRIPTION
This PR standardizes the format and filename conventions for chatlogs generated by the `save_and_upload_chat_log` tool.

**Changes Implemented:**

1.  **Chatlog Content Formatting:**
    *   Removed metadata headers (Editor, Project Name, Project Path, Workspace Name, Conversation Titles, Created/Last Updated timestamps) from the chatlog content.
    *   Ensured all chatlogs are formatted consistently with the pattern:
        ```
        user: <message content>

        assistant: <message content>
        ```
    *   This change affects the formatting functions in:
        *   `src/handlers/parser/cursorChatParser.ts`
        *   `src/handlers/parser/zedChatParser.ts`
        *   `src/handlers/parser/clineChatParser.ts` (specifically `formatClineChatLogForUpload` and its helper `formatClineMessagesToMarkdownBody`)

2.  **Chatlog Filename Convention:**
    *   Modified `src/handlers/handleSaveAndUploadChatLog.ts` to include the `editorType` in filenames.
    *   **Local Filename:** `chat_log_{editorType}_{safeUserId}_{safeProjectName}_{timestamp}.md`
    *   **GitHub Filename:** `chat_log_{editorType}_{timestamp}.md` (uploaded to `project-logs/{safeProjectName}/{safeUserId}/{sourceDirName}/`)

**Reason for Changes:**

*   Simplifies the chatlog content to focus purely on the conversation.
*   Improves discoverability and organization of chatlogs by including the editor type in the filename, making it easier to identify the source of the log.