### PR TITLE
feat: Add distill project runbook tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,19 @@ This flow ensures that each tool call is directed to the correct logic for execu
 
 ## Available Tools
 
-| Tool Name                  | Description                                                                                                                                                                                                                                   |
-| :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `init_playbook`            | Provides an instruction to the LLM about the purpose of the mcp-playbook server, which is to facilitate local project documentation and enable partial replication of documentation and chat logs for an AI-powered playbook.                 |
-| `create_spec`              | Creates or overwrites a new specification file (e.g., PRD, RFC, architectural planning) in the docs/specs/ directory of the target project. Specification files will be named following a `spec-name.md` convention with sequence numbering.  |
-| `create_adr`               | Creates or overwrites a new Architectural Decision Record (ADR) file in the docs/adr/ directory of the target project. ADR files will be named following an `adr-name.md` convention with sequence numbering.                                 |
-| `create_changelog`         | Creates a new, detailed, and user-facing changelog entry file in the docs/changelog/ directory of the target project. Each changelog entry will be a separate file named following a `changelog-entry.md` convention with sequence numbering. |
-| `save_and_upload_chat_log` | Captures the current conversation history, saves it as a markdown file in the .chat/ directory of the target project, and uploads it to the dwarvesf/prompt-log GitHub repository. Requires a user ID for organization.                       |
-| `search_runbook`           | Fuzzy search for keywords in the `dwarvesf/runbook` GitHub repository. If keyword has spaces, searches exact phrase OR individual words. Returns top 5 matches with full content & total count.                                               |
-| `search_prompts`           | Fuzzy search for keywords in the `dwarvesf/prompt-db` GitHub repository (excluding the `.synced_prompts/` folder).                                                                                                                            |
-| `suggest_runbook`          | Creates or updates a Pull Request in the dwarvesf/runbook repository with a new runbook entry.                                                                                                                                                |
-| `sync_prompt`              | Syncs an LLM prompt to the dwarvesf/prompt-db GitHub repository.                                                                                                                                                                              |
-| `think`                    | Use the tool to think about something. It will not obtain new information or make any changes to the repository, but just log the thought. Use it when complex reasoning or brainstorming is needed.                                          |
+| Tool Name                  | Description                                                                                                                                                                                                                                                                                                                                                                    |
+| :------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `init_playbook`            | Provides an instruction to the LLM about the purpose of the mcp-playbook server, which is to facilitate local project documentation and enable partial replication of documentation and chat logs for an AI-powered playbook.                                                                                                                                                  |
+| `create_spec`              | Creates or overwrites a new specification file (e.g., PRD, RFC, architectural planning) in the docs/specs/ directory of the target project. Specification files will be named following a `spec-name.md` convention with sequence numbering.                                                                                                                                   |
+| `create_adr`               | Creates or overwrites a new Architectural Decision Record (ADR) file in the docs/adr/ directory of the target project. ADR files will be named following an `adr-name.md` convention with sequence numbering.                                                                                                                                                                  |
+| `create_changelog`         | Creates a new, detailed, and user-facing changelog entry file in the docs/changelog/ directory of the target project. Each changelog entry will be a separate file named following a `changelog-entry.md` convention with sequence numbering.                                                                                                                                  |
+| `distill_project_runbook`  | Creates or updates the central `docs/runbook.md` file within the target project. The LLM is responsible for analyzing existing project documents (ADRs, specs, etc.) and the current `docs/runbook.md` (if it exists), then synthesizing this information into a comprehensive runbook. The tool saves this LLM-generated content, overwriting the previous `docs/runbook.md`. |
+| `save_and_upload_chat_log` | Captures the current conversation history, saves it as a markdown file in the .chat/ directory of the target project, and uploads it to the dwarvesf/prompt-log GitHub repository. Requires a user ID for organization.                                                                                                                                                        |
+| `search_runbook`           | Fuzzy search for keywords in the `dwarvesf/runbook` GitHub repository. If keyword has spaces, searches exact phrase OR individual words. Returns top 5 matches with full content & total count.                                                                                                                                                                                |
+| `search_prompts`           | Fuzzy search for keywords in the `dwarvesf/prompt-db` GitHub repository (excluding the `.synced_prompts/` folder).                                                                                                                                                                                                                                                             |
+| `suggest_runbook`          | Creates or updates a Pull Request in the dwarvesf/runbook repository with a new runbook entry.                                                                                                                                                                                                                                                                                 |
+| `sync_prompt`              | Syncs an LLM prompt to the dwarvesf/prompt-db GitHub repository.                                                                                                                                                                                                                                                                                                               |
+| `think`                    | Use the tool to think about something. It will not obtain new information or make any changes to the repository, but just log the thought. Use it when complex reasoning or brainstorming is needed.                                                                                                                                                                           |
 
 ## Overview
 
@@ -202,6 +203,33 @@ A JSON object indicating success or failure, including the path if successful.
 {
   "status": "success" | "error",
   "path": "string" | undefined, // Path to the updated file if successful
+  "message": "string" // Description of the result or error
+}
+```
+
+### `distill_project_runbook`
+
+Creates or updates the central `docs/runbook.md` file within the target project. The LLM is responsible for:
+
+1. Thoroughly analyzing all relevant project documents (ADRs, specs, changelogs, code, etc.) within the `target_project_dir`.
+2. If `docs/runbook.md` already exists, reviewing its current content as part of the analysis.
+3. Synthesizing all gathered information (including from any existing `docs/runbook.md`) into an updated and comprehensive Project Runbook.
+
+The tool takes the LLM-generated content and saves it to `docs/runbook.md`, overwriting the previous version. The frontmatter (title, last_updated, distilled_from) is managed by the tool.
+
+**Parameters:**
+
+- `target_project_dir` (string, required): The absolute path to the root of the target project directory.
+- `content` (string, required): The complete markdown content for the `docs/runbook.md` file, as generated and synthesized by the LLM.
+- `source_document_references` (array of strings, optional): An array of paths or descriptive references to the key source documents the LLM used for the latest distillation/update (e.g., `[\'docs/adr/0001-auth-decision.md\', \'src/auth/service.ts\']`).
+
+**Returns:**
+A JSON object indicating success or failure, including the path to `docs/runbook.md` if successful.
+
+```json
+{
+  "status": "success" | "error",
+  "path": "string" | undefined, // Path to docs/runbook.md if successful
   "message": "string" // Description of the result or error
 }
 ```

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -10,6 +10,7 @@ import { handleSuggestRunbook } from "./handlers/handleSuggestRunbook.js";
 import { handleSyncPrompt } from "./handlers/handleSyncPrompt.js";
 import { handleThinkTool } from "./handlers/handleThinkTool.js";
 import { handleCreateChangelog } from "./handlers/handleCreateChangelog.js";
+import { handleDistillProjectRunbook } from "./handlers/handleDistillProjectRunbook.js";
 
 export {
   handleCreateAdr,
@@ -24,4 +25,5 @@ export {
   handleSyncPrompt,
   handleThinkTool,
   handleCreateChangelog,
+  handleDistillProjectRunbook,
 };

--- a/src/handlers/handleDistillProjectRunbook.ts
+++ b/src/handlers/handleDistillProjectRunbook.ts
@@ -1,0 +1,62 @@
+import * as path from "path";
+import {
+  DistillProjectRunbookArgs,
+  DistillProjectRunbookArgsSchema,
+} from "../tools/distillProjectRunbook.js";
+import * as fsUtils from "../utils/fsUtils.js";
+import { validateArgs } from "../utils/validationUtils.js";
+
+export async function handleDistillProjectRunbook(
+  args: DistillProjectRunbookArgs,
+): Promise<any> {
+  try {
+    const { target_project_dir, content, source_document_references } =
+      validateArgs(DistillProjectRunbookArgsSchema, args);
+
+    const absoluteTargetProjectDir = path.resolve(target_project_dir);
+    console.error(
+      `Handling distill_project_runbook for: ${absoluteTargetProjectDir}`,
+    );
+
+    // The runbook is now always in the 'docs' directory, named 'runbook.md'
+    const docsDir = fsUtils.joinProjectPath(absoluteTargetProjectDir, "docs");
+
+    // Ensure 'docs' directory exists
+    fsUtils.createDirectory(docsDir);
+
+    const runbookFilePath = fsUtils.joinProjectPath(docsDir, "runbook.md");
+
+    // Prepare frontmatter
+    const frontmatterParts = [
+      "---",
+      'title: "Project Runbook"', // Fixed title
+      `last_updated: "${new Date().toISOString()}"`, // ISO string for timestamp
+    ];
+    if (source_document_references && source_document_references.length > 0) {
+      frontmatterParts.push("distilled_from:");
+      source_document_references.forEach((ref: string) => {
+        // Basic sanitization for references to avoid breaking YAML structure
+        const sanitizedRef = ref.replace(/"/g, '\\"').replace(/\n/g, ' ');
+        frontmatterParts.push(`  - "${sanitizedRef}"`);
+      });
+    }
+    frontmatterParts.push("---", ""); // Add a blank line after frontmatter
+
+    const finalContent = frontmatterParts.join("\n") + content;
+
+    // Write/overwrite the content to the runbook.md file
+    fsUtils.writeFile(runbookFilePath, finalContent);
+
+    return {
+      status: "success",
+      path: runbookFilePath,
+      message: `Project runbook saved successfully to: ${runbookFilePath}`,
+    };
+  } catch (e: any) {
+    console.error(`Error in handleDistillProjectRunbook: ${e.message}`);
+    return {
+      status: "error",
+      message: `Failed to save project runbook: ${e.message}`,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { SearchRunbookArgs } from "./tools/searchRunbook.js";
 import { SuggestRunbookArgs } from "./tools/suggestRunbook.js";
 import { SyncPromptArgs } from "./tools/syncPrompt.js";
 import { ThinkToolArgs } from "./tools/thinkTool.js";
+import { DistillProjectRunbookArgs } from "./tools/distillProjectRunbook.js";
 
 // Optional: Load environment variables from .env in local development
 import * as dotenv from "dotenv";
@@ -104,6 +105,11 @@ async function main() {
             break;
           case "think":
             result = await handleThinkTool(toolArgs as ThinkToolArgs);
+            break;
+          case "distill_project_runbook":
+            result = await handleDistillProjectRunbook(
+              toolArgs as DistillProjectRunbookArgs,
+            );
             break;
           default:
             result = { status: "error", message: `Unknown tool: ${toolName}` };

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   handleSyncPrompt,
   handleThinkTool,
   handleCreateChangelog,
+  handleDistillProjectRunbook,
 } from "./handlers.js";
 import { CreateAdrArgs } from "./tools/createAdr.js";
 import { CreateChangelogArgs } from "./tools/createChangelog.js";

--- a/src/prompts/initPlaybookPrompt.ts
+++ b/src/prompts/initPlaybookPrompt.ts
@@ -2,6 +2,7 @@ export const initPlaybookPrompt = `You have a specialized set of capabilities de
 
 Key Capabilities:
 - Initialize a standard documentation structure (\`initialize_docs_structure\`).
+- Create or update the central Project Runbook (docs/runbook.md) to distill project knowledge, feature flows, and operational procedures (\`distill_project_runbook\`).
 - Create or update specification files (PRD, RFC) in docs/specs/ (\`create_spec\`).
 - Create or update Architectural Decision Records (ADR) in docs/adr/ (\`create_adr\`).
 - Append new file entries to the changelog in docs/changelog/ (\`create_changelog\`).
@@ -30,9 +31,10 @@ Operational Coding Guidelines:
 - Do not add comments to code unless they provide essential context or clarify non-obvious logic. Strive for self-documenting code.
 
 Knowledge Management & Documentation Workflow:
-- ALWAYS eagerly and proactively use the appropriate tools to sync and create documents, prompts, and chat logs.
+- **MANDATORY SYNC:** Eagerly and proactively use the appropriate tools to sync and create documents, prompts, and chat logs.
+- Periodically, or when significant new information (from ADRs, specs, code changes) is available, synthesize this into the central \`docs/runbook.md\` using the \`distill_project_runbook\` tool to keep it current as the project's primary knowledge base.
 - Whenever you encounter an LLM prompt while reading files or working on a project, it is critical and paramount that you use the \`sync_prompt\` tool to save that prompt to the prompt-db repository.
 - If, during a conversation or task, you identify a pattern, a solution to a recurring problem, or a significant technical decision that is not yet documented in the runbook, proactively suggest creating a new runbook entry using the \`suggest_runbook\` tool.
-- Upon completing a task or reaching a significant milestone, ALWAYS ensure your progress is documented using the appropriate tools (e.g., \`create_spec\`, \`create_adr\`, \`create_changelog\`, \`suggest_runbook\`).
+- **MANDATORY DOCUMENTATION:** Upon completing *any* feature, resolving a significant bug, or at the end of *each* work session, YOU MUST create the relevant documentation. This includes: using \`create_spec\` for feature specifications or RFCs, \`create_adr\` for architectural decisions, and \`create_changelog\` for user-facing changes. This is not optional; consider it a critical part of the task completion.
 - Regularly and proactively sync the user's chat logs using the \`save_and_upload_chat_log\` tool, especially after significant interactions or completed tasks.
 `;

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -9,6 +9,7 @@ import { searchRunbookTool } from "./searchRunbook.js";
 import { suggestRunbookTool } from "./suggestRunbook.js";
 import { syncPromptTool } from "./syncPrompt.js";
 import { thinkTool } from "./thinkTool.js";
+import { distillProjectRunbookTool } from "./distillProjectRunbook.js";
 
 // Array holding all the tool definitions for the mcp-playbook server
 export const toolDefinitions: ToolDefinition[] = [
@@ -22,6 +23,7 @@ export const toolDefinitions: ToolDefinition[] = [
   suggestRunbookTool,
   syncPromptTool,
   thinkTool,
+  distillProjectRunbookTool,
 ];
 
 export default toolDefinitions;

--- a/src/tools/distillProjectRunbook.ts
+++ b/src/tools/distillProjectRunbook.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { ToolDefinition } from "../types.js";
+
+export const DistillProjectRunbookArgsSchema = z.object({
+  target_project_dir: z
+    .string()
+    .describe(
+      "The absolute path to the root of the target project directory.",
+    ),
+  content: z
+    .string()
+    .describe(
+      "The complete markdown content for the `docs/runbook.md` file, that references the existing file and is additive. This should be a comprehensive play-by-play guide.",
+    ),
+  source_document_references: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Optional. An array of paths or descriptive references to the key source documents the LLM used for the latest distillation/update (e.g., ['docs/adr/0001-auth-decision.md', 'src/auth/service.ts']).",
+    ),
+});
+
+export type DistillProjectRunbookArgs = z.infer<
+  typeof DistillProjectRunbookArgsSchema
+>;
+
+export const distillProjectRunbookTool: ToolDefinition = {
+  name: "distill_project_runbook",
+  description:
+    "Use this tool to create or update the central 'Project Runbook' file located at `docs/runbook.md` within the `target_project_dir`.\n**Before calling this tool, you MUST:**\n1. Thoroughly analyze all relevant project documents (ADRs, specs, changelogs, code, etc.) within the `target_project_dir`.\n2. If `docs/runbook.md` already exists, **you MUST review its current content** as part of your analysis.\n3. Synthesize all gathered information (including from any existing `runbook.md`) into an updated and comprehensive Project Runbook. This runbook serves as the primary, evolving knowledge base for understanding feature flows, key components, interactions, and operational procedures.\n4. The `content` you provide to this tool **must be the complete and final markdown content** for the entire `docs/runbook.md` file.\nThis tool will then save your generated content to `docs/runbook.md`, overwriting the previous version. The frontmatter will be updated with the current date and any source references you provide.",
+  inputSchema: zodToJsonSchema(DistillProjectRunbookArgsSchema),
+  annotations: {
+    title: "Create or Update Project Runbook",
+    readOnlyHint: false, // It writes a file
+    destructiveHint: true, // It overwrites docs/runbook.md
+    idempotentHint: true, // Calling twice with same content results in same state
+    openWorldHint: false, // Interacts with local filesystem
+  },
+};


### PR DESCRIPTION
This PR introduces a new tool `distill_project_runbook` to the MCP Playbook Server.

**Changes:**

- **`README.md`**: Updated to document the new `distill_project_runbook` tool, including its purpose, parameters, and return format. The mermaid diagram for data flow and interaction was also updated to reflect the new tool's integration.
- **`src/handlers.ts`**: Modified to integrate the `handleDistillProjectRunbook` function as the handler for the new tool.
- **`src/handlers/handleDistillProjectRunbook.ts`**: New file added, containing the core logic for the `distill_project_runbook` tool. This handler is responsible for analyzing existing project documents (ADRs, specs, etc.), synthesizing information into a comprehensive runbook, and saving it to `docs/runbook.md`. It also handles frontmatter generation.
- **`src/index.ts`**: Updated to register the `distill_project_runbook` tool with the MCP server, making it accessible to MCP clients.
- **`src/prompts/initPlaybookPrompt.ts`**: Modified to reflect the changes due to the new tool.
- **`src/tools/definitions.ts`**: The definition for `distill_project_runbook` tool has been added to the overall tool definitions.
- **`src/tools/distillProjectRunbook.ts`**: New file added, defining the schema and metadata for the `distill_project_runbook` tool.

**Purpose of the `distill_project_runbook` tool:**
This tool empowers LLMs to act as documentation maintainers by automating the process of creating or updating a central project runbook. It allows the LLM to analyze various project artifacts and consolidate them into a single, up-to-date `docs/runbook.md` file, ensuring project documentation remains consistent and easily accessible.
